### PR TITLE
feat: Add max file size limit option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ to your clipboard, ready for LLM processing.
 
 - 🎮 **Interactive Mode**: Navigate your project structure with vim-like keybindings in a
   TUI environment
-- 🧹 **Filtering Options**: Respect `.gitignore` rules, handle hidden files, and apply customizable glob
-  patterns
+- 🧹 **Filtering Options**: Respect `.gitignore` rules, handle hidden files, apply customizable glob
+  patterns, and skip large files
 - 🔍 **Fuzzy Search**: Quickly find files across your project
 - ✅ **File Selection**: Toggle files or entire directories (with child items) for inclusion or exclusion
 - 📄 **Multiple Output Formats**: Generate Markdown, Plain Text, or XML output
@@ -59,7 +59,7 @@ cd codegrab
 go build ./cmd/grab
 ```
 
-Then move the binary to your `PATH`
+Then move the binary to your `PATH`.
 
 ## 🚀 Quick Start
 
@@ -69,9 +69,9 @@ Then move the binary to your `PATH`
    grab
    ```
 
-2. Navigate with <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd>
-3. Select files using the <kbd>Space</kbd> or <kbd>Tab</kbd> key
-4. Press <kbd>g</kbd> to generate output file or <kbd>y</kbd> to copy contents to clipboard
+2. Navigate with arrow keys or <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd>.
+3. Select files using the <kbd>Space</kbd> or <kbd>Tab</kbd> key.
+4. Press <kbd>g</kbd> to generate output file or <kbd>y</kbd> to copy contents to clipboard.
 
 CodeGrab will generate `codegrab-output.md` in your current working directory (on macOS this file is automatically copied to your clipboard), which you can immediately send to an AI assistant for better context-aware coding assistance.
 
@@ -85,25 +85,26 @@ grab [options] [directory]
 
 ### Arguments
 
-| Argument    | Description                                                        |
-| :---------- | :----------------------------------------------------------------- |
-| `directory` | Path to the project directory (default: current working directory) |
+| Argument    | Description                                           |
+| :---------- | :---------------------------------------------------- |
+| `directory` | Optional path to the project directory (default: ".") |
 
 ### Options
 
-| Option                  | Description                                                                             |
-| :---------------------- | :-------------------------------------------------------------------------------------- |
-| `-h, --help`            | Display help information                                                                |
-| `-v, --version`         | Display version information                                                             |
-| `-n, --non-interactive` | Run in non-interactive mode (grabs all files)                                           |
-| `-o, --output file`     | Output file path (default: `./codegrab-output.<format>`)                                |
-| `-t, --temp`            | Use system temporary directory for output file                                          |
-| `-g, --glob pattern`    | Include/exclude files and directories (e.g., `--glob="*.{ts,tsx}" --glob="\!*.spec.ts"`) |
-| `-f, --format format`   | Output format (available: markdown, text, xml)                                          |
-| `-S, --skip-redaction`  | Skip automatic secret redaction (WARNING: This may expose sensitive information)        |
-| `--deps`                | Automatically include direct dependencies (Go, JS/TS)                                   |
-| `--max-depth depth`     | Maximum depth for dependency resolution (-1 for unlimited, default: 1)                  |
-| `--theme`               | Set the UI theme                                                                        |
+| Option                   | Description                                                                                                                                                           |
+| :----------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-h, --help`             | Display help information.                                                                                                                                             |
+| `-v, --version`          | Display version information.                                                                                                                                          |
+| `-n, --non-interactive`  | Run in non-interactive mode (selects all valid files respecting filters).                                                                                             |
+| `-o, --output <file>`    | Output file path (default: `./codegrab-output.<format>`).                                                                                                             |
+| `-t, --temp`             | Use system temporary directory for output file.                                                                                                                       |
+| `-g, --glob <pattern>`   | Include/exclude files and directories using glob patterns. Can be used multiple times. Prefix with '!' to exclude (e.g., `--glob="*.{ts,tsx}" --glob="\!*.spec.ts"`). |
+| `-f, --format <format>`  | Output format. Available: `markdown`, `text`, `xml` (default: `"markdown"`).                                                                                          |
+| `-S, --skip-redaction`   | Skip automatic secret redaction via gitleaks (Default: false). WARNING: Disabling this may expose sensitive information!                                              |
+| `--deps`                 | Automatically include direct dependencies for selected files (Go, JS/TS).                                                                                             |
+| `--max-depth <depth>`    | Maximum depth for dependency resolution (`-1` for unlimited, default: `1`). Only effective with `--deps`.                                                             |
+| `--max-file-size <size>` | Maximum file size to include (e.g., `"100kb"`, `"2MB"`). No limit by default. Files exceeding the specified size will be skipped.                                     |
+| `--theme <name>`         | Set the UI theme. Available: catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, catppuccin-mocha, dracula, nord. (default: `"catppuccin-mocha"`).             |
 
 ### 📖 Examples
 
@@ -113,22 +114,22 @@ grab [options] [directory]
    grab
    ```
 
-2. Grab all files in current directory (non-interactive):
+2. Grab all files in current directory (non-interactive), skipping files > 50kb:
 
    ```bash
-   grab -n
+   grab -n --max-file-size 50kb
    ```
 
-3. Grab a specific directory interactively:
+3. Grab a specific directory interactively including dependencies:
 
    ```bash
-   grab /path/to/project
+   grab --deps /path/to/project
    ```
 
 4. Grab a specific directory non-interactively including all dependencies (unlimited depth):
 
    ```bash
-   grab -n --deps --max-depth -1
+   grab -n --deps --max-depth -1 /path/to/project
    ```
 
 5. Specify custom output file:
@@ -171,13 +172,13 @@ grab [options] [directory]
 
 ### Search
 
-| Action                 | Key                               | Description                                            |
-| :--------------------- | :-------------------------------- | :----------------------------------------------------- |
-| Start search           | <kbd>/</kbd>                      | Begin searching for files                              |
-| Next search result     | <kbd>ctrl+n</kbd> or <kbd>↓</kbd> | Navigate to the next search result                     |
-| Previous search result | <kbd>ctrl+p</kbd> or <kbd>↑</kbd> | Navigate to the previous search result                 |
-| Select/deselect file   | <kbd>tab</kbd>                    | Toggle selection of the current file in search results |
-| Exit search            | <kbd>esc</kbd>                    | Exit search mode and return to normal navigation       |
+| Action                 | Key                               | Description                                                 |
+| :--------------------- | :-------------------------------- | :---------------------------------------------------------- |
+| Start search           | <kbd>/</kbd>                      | Begin fuzzy searching for files                             |
+| Next search result     | <kbd>ctrl+n</kbd> or <kbd>↓</kbd> | Navigate to the next search result                          |
+| Previous search result | <kbd>ctrl+p</kbd> or <kbd>↑</kbd> | Navigate to the previous search result                      |
+| Select/deselect item   | <kbd>tab</kbd> / <kbd>enter</kbd> | Toggle selection of the item under cursor in search results |
+| Exit search            | <kbd>esc</kbd>                    | Exit search mode and return to normal navigation            |
 
 ### Selection & Output
 
@@ -192,19 +193,19 @@ grab [options] [directory]
 
 ### View Options
 
-| Action                     | Key          | Description                                       |
-| :------------------------- | :----------- | :------------------------------------------------ |
-| Toggle `.gitignore` filter | <kbd>i</kbd> | Toggle whether to respect `.gitignore` rules      |
-| Toggle hidden files        | <kbd>.</kbd> | Toggle visibility of hidden files and directories |
-| Refresh files & folders    | <kbd>r</kbd> | Reload directory tree and reset selections        |
-| Toggle help screen         | <kbd>?</kbd> | Show or hide the help screen                      |
-| Quit                       | <kbd>q</kbd> | Exit the application                              |
+| Action                     | Key                              | Description                                  |
+| :------------------------- | :------------------------------- | :------------------------------------------- |
+| Toggle `.gitignore` filter | <kbd>i</kbd>                     | Toggle whether to respect `.gitignore` rules |
+| Toggle hidden files        | <kbd>.</kbd>                     | Toggle visibility of hidden files            |
+| Refresh files & folders    | <kbd>r</kbd>                     | Reload directory tree and reset selections   |
+| Toggle help screen         | <kbd>?</kbd>                     | Show or hide the help screen                 |
+| Quit                       | <kbd>q</kbd> / <kbd>ctrl+c</kbd> | Exit the application                         |
 
 ## 🔗 Automatic Dependency Resolution
 
 CodeGrab can automatically include dependencies for selected files, making it easier to share complete code snippets with LLMs.
 
-- **How it works**: When enabled, CodeGrab utilizes [tree-sitter](https://tree-sitter.github.io/tree-sitter/) to parse selected source files, identifying language-specific dependency declarations (like `import` or `require`). It then attempts to resolve these dependencies within your project and automatically includes the necessary files.
+- **How it works**: When enabled, CodeGrab utilizes [tree-sitter](https://tree-sitter.github.io/tree-sitter/) to parse selected source files, identifying language-specific dependency declarations (like `import` or `require`). It then attempts to resolve these dependencies within your project and automatically includes the necessary files (respecting `.gitignore`, hidden, size, and glob filters).
 - **Supported Languages**:
   - **Go**: Resolves relative imports and project-local module imports (if `go.mod` is present).
   - **JavaScript/TypeScript**: Resolves relative imports/requires for `.js`, `.jsx`, `.ts`, and `.tsx` files, including directory `index` files.

--- a/internal/filesystem/walker_test.go
+++ b/internal/filesystem/walker_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -15,27 +16,26 @@ func TestWalkDirectory(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		testFiles := []string{
-			"file1.txt",
-			"file2.go",
-			"subdir/file3.txt",
-			"subdir/file4.go",
-			".hidden/file5.txt",
+		testFilesSetup := map[string]string{
+			"small.txt":        "small",                                // 5 bytes
+			"medium.txt":       strings.Repeat("a", 500),               // 500 bytes
+			"large.txt":        strings.Repeat("b", 1500),              // 1500 bytes
+			"subdir/small.go":  "package small",                        // 13 bytes
+			"subdir/large.go":  "// " + strings.Repeat("c", 2000),      // ~2004 bytes
+			".hidden/huge.txt": strings.Repeat("d", 5000),              // 5000 bytes
+			"binary.bin":       string([]byte{0x00, 0x01, 0x02, 0x00}), // Binary file to test IsTextFile
 		}
 
-		for _, file := range testFiles {
+		for file, content := range testFilesSetup {
 			path := filepath.Join(tempDir, filepath.FromSlash(file))
 			dir := filepath.Dir(path)
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				t.Fatalf("Failed to create directory %s: %v", dir, err)
 			}
-			if err := os.WriteFile(path, []byte("test content "+file), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 				t.Fatalf("Failed to create file %s: %v", path, err)
 			}
 		}
-
-		filter := NewFilterManager()
-		filter.AddGlobPattern("*.go")
 
 		gitIgnore, err := NewGitIgnoreManager(tempDir)
 		if err != nil {
@@ -43,64 +43,130 @@ func TestWalkDirectory(t *testing.T) {
 		}
 
 		testCases := []struct {
-			name         string
-			checkFile    string
-			expectedLen  int
-			useGitIgnore bool
-			showHidden   bool
-			shouldExist  bool
-			maxFileSize  int64
+			expectedFiles    map[string]bool
+			name             string
+			filterPatterns   []string
+			maxFileSize      int64
+			useGitIgnore     bool
+			showHidden       bool
+			expectExcludeBin bool
 		}{
 			{
-				name:         "Filter Go files only",
-				useGitIgnore: false,
-				showHidden:   false,
-				expectedLen:  3,
-				checkFile:    "file2.go",
-				shouldExist:  true,
-				maxFileSize:  math.MaxInt64,
+				name:           "No filters, default max size",
+				filterPatterns: []string{},
+				useGitIgnore:   false,
+				showHidden:     false,
+				maxFileSize:    math.MaxInt64,
+				expectedFiles: map[string]bool{
+					"small.txt":       true,
+					"medium.txt":      true,
+					"large.txt":       true,
+					"subdir":          true,
+					"subdir/small.go": true,
+					"subdir/large.go": true,
+				},
+				expectExcludeBin: true,
 			},
 			{
-				name:         "Show hidden files",
-				useGitIgnore: false,
-				showHidden:   true,
-				expectedLen:  4,
-				checkFile:    ".hidden",
-				shouldExist:  true,
-				maxFileSize:  math.MaxInt64,
+				name:           "Limit 1kb, include all text",
+				filterPatterns: []string{"*"},
+				useGitIgnore:   false,
+				showHidden:     false,
+				maxFileSize:    1024,
+				expectedFiles: map[string]bool{
+					"small.txt":       true,
+					"medium.txt":      true,
+					"subdir":          true,
+					"subdir/small.go": true,
+				},
+				expectExcludeBin: true,
+			},
+			{
+				name:           "Limit 1kb, filter *.go",
+				filterPatterns: []string{"*.go"},
+				useGitIgnore:   false,
+				showHidden:     false,
+				maxFileSize:    1024,
+				expectedFiles: map[string]bool{
+					"subdir":          true,
+					"subdir/small.go": true,
+				},
+				expectExcludeBin: true,
+			},
+			{
+				name:           "Show hidden, limit 4kb",
+				filterPatterns: []string{"*"},
+				useGitIgnore:   false,
+				showHidden:     true,
+				maxFileSize:    4 * 1024,
+				expectedFiles: map[string]bool{
+					"small.txt":       true,
+					"medium.txt":      true,
+					"large.txt":       true,
+					"subdir":          true,
+					"subdir/small.go": true,
+					"subdir/large.go": true,
+					".hidden":         true,
+				},
+				expectExcludeBin: true,
+			},
+			{
+				name:           "No limit, exclude binary",
+				filterPatterns: []string{"*"},
+				useGitIgnore:   false,
+				showHidden:     false,
+				maxFileSize:    math.MaxInt64,
+				expectedFiles: map[string]bool{
+					"small.txt":       true,
+					"medium.txt":      true,
+					"large.txt":       true,
+					"subdir":          true,
+					"subdir/small.go": true,
+					"subdir/large.go": true,
+				},
+				expectExcludeBin: true,
 			},
 		}
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				filter := NewFilterManager()
+				for _, p := range tc.filterPatterns {
+					filter.AddGlobPattern(p)
+				}
+
 				files, err := WalkDirectory(tempDir, gitIgnore, filter, tc.useGitIgnore, tc.showHidden, tc.maxFileSize)
 				if err != nil {
 					t.Fatalf("WalkDirectory failed: %v", err)
 				}
 
+				foundFilesMap := make(map[string]bool)
 				var foundPaths []string
 				for _, f := range files {
+					foundFilesMap[f.Path] = true
 					foundPaths = append(foundPaths, f.Path)
 				}
 				t.Logf("Found files (%d): %v", len(files), foundPaths)
 
-				if len(files) != tc.expectedLen {
-					t.Errorf("Expected %d files, got %d", tc.expectedLen, len(files))
+				if len(files) != len(tc.expectedFiles) {
+					t.Errorf("Expected %d files, got %d. Expected: %v, Got: %v", len(tc.expectedFiles), len(files), tc.expectedFiles, foundFilesMap)
 				}
 
-				found := false
-				for _, file := range files {
-					if file.Path == tc.checkFile {
-						found = true
-						break
+				for expectedPath := range tc.expectedFiles {
+					if !foundFilesMap[expectedPath] {
+						t.Errorf("Expected to find '%s' but didn't", expectedPath)
+					}
+				}
+				for foundPath := range foundFilesMap {
+					if !tc.expectedFiles[foundPath] {
+						t.Errorf("Found unexpected file '%s'", foundPath)
 					}
 				}
 
-				if found != tc.shouldExist {
-					if tc.shouldExist {
-						t.Errorf("Expected to find %s but didn't", tc.checkFile)
-					} else {
-						t.Errorf("Expected not to find %s but did", tc.checkFile)
+				// Explicitly check binary exclusion if expected
+				if tc.expectExcludeBin {
+					if foundFilesMap["binary.bin"] {
+						t.Errorf("Expected 'binary.bin' to be excluded, but it was found")
 					}
 				}
 			})

--- a/internal/model/display.go
+++ b/internal/model/display.go
@@ -9,6 +9,11 @@ import (
 	"github.com/epilande/codegrab/internal/filesystem"
 )
 
+// buildDisplayNodes constructs a hierarchical view of files and directories for display.
+// It creates FileNode objects for each item, properly indented based on directory depth,
+// respects collapsed/expanded states of directories, marks selected/deselected items,
+// identifies dependencies, and sorts files and directories.
+// The resulting displayNodes slice is used for rendering the file tree in the UI.
 func (m *Model) buildDisplayNodes() {
 	m.displayNodes = nil
 	nodesToAdd := make(map[string]filesystem.FileItem)

--- a/internal/model/init_update.go
+++ b/internal/model/init_update.go
@@ -242,6 +242,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.collapsed) > 0 {
 				m.expandAllDirectories()
 			} else {
+				m.cursor = 0
+				m.viewport.GotoTop()
 				m.collapseAllDirectories()
 			}
 			m.ensureCursorVisible()
@@ -273,8 +275,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.refreshViewportContent()
 			}
 		case "esc":
-			m.showHelp = false
-			m.refreshViewportContent()
+			if m.showHelp {
+				m.showHelp = false
+				m.refreshViewportContent()
+			}
 		case "y":
 			return m, m.copyOutputToClipboard()
 		case "g":
@@ -300,6 +304,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.successMsg = "Dependency resolution disabled"
 			}
+			m.buildDisplayNodes()
 			m.refreshViewportContent()
 		case "F":
 			formatNames := formats.GetFormatNames()
@@ -339,7 +344,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *Model) reloadFiles() tea.Cmd {
 	return func() tea.Msg {
-		files, err := filesystem.WalkDirectory(m.rootPath, m.gitIgnoreMgr, m.filterMgr, m.useGitIgnore, m.showHidden)
+		files, err := filesystem.WalkDirectory(m.rootPath, m.gitIgnoreMgr, m.filterMgr, m.useGitIgnore, m.showHidden, m.maxFileSize)
 		if err != nil {
 			return filesLoadedMsg{files: nil, err: fmt.Errorf("failed to reload files: %w", err)}
 		}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -48,6 +48,7 @@ type Model struct {
 	width             int
 	height            int
 	maxDepth          int
+	maxFileSize       int64
 	showHelp          bool
 	useGitIgnore      bool
 	showHidden        bool
@@ -63,6 +64,7 @@ type Config struct {
 	OutputPath    string
 	Format        string
 	MaxDepth      int
+	MaxFileSize   int64
 	UseTempFile   bool
 	SkipRedaction bool
 	ResolveDeps   bool
@@ -95,6 +97,7 @@ func NewModel(config Config) Model {
 		redactSecrets:     !config.SkipRedaction,
 		resolveDeps:       config.ResolveDeps,
 		maxDepth:          config.MaxDepth,
+		maxFileSize:       config.MaxFileSize,
 		projectModuleName: moduleName,
 		showHidden:        false,
 		searchInput:       ui.NewSearchInput(),
@@ -102,5 +105,6 @@ func NewModel(config Config) Model {
 			Width:  80,
 			Height: 10,
 		},
+		cursor: 0,
 	}
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -271,8 +272,9 @@ func TestToggleSelection(t *testing.T) {
 	}
 
 	config := Config{
-		RootPath:  tempDir,
-		FilterMgr: filesystem.NewFilterManager(),
+		RootPath:    tempDir,
+		FilterMgr:   filesystem.NewFilterManager(),
+		MaxFileSize: math.MaxInt64,
 	}
 	m := NewModel(config)
 	m.files = fileItems

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -13,12 +13,12 @@ Search:
   /                        Start search
   ctrl+n / ↓               Next search result
   ctrl+p / ↑               Previous search result
-  tab                      Select/deselect file in search
-  esc                      Exit search
+  tab / enter              Select/deselect file in search results
+  esc                      Exit search mode
 
 Selection & Output:
   space / tab              Select/deselect file or directory
-  y                        Copy output to clipboard
+  y                        Copy generated output to clipboard
   g                        Generate output file
   D                        Toggle automatic dependency resolution (Go, TS/JS)
   F                        Cycle through output formats (md, txt, xml)
@@ -29,45 +29,50 @@ View Options:
   .                        Toggle hidden files
   r                        Refresh file list & reset selection
   ?                        Toggle help screen
-  q                        Quit`
+  q / ctrl+c               Quit`
 
 const UsageText = `Usage:
   grab [options] [directory]
 
   Options:
-    -h, --help               Display this help information
-    -n, --non-interactive    Run in non-interactive mode
-    -o, --output file        Output file path (default: current directory)
-    -t, --temp               Use system temporary directory for output file
-    -g, --glob pattern       Include/exclude files and directories
-                             (e.g., --glob="*.{ts,tsx}" --glob="\!*.spec.ts")
-    -f, --format format      Output format (available: markdown, text, xml)
-    -S, --skip-redaction     Skip automatic secret redaction (Default: false)
+    -h, --help               Display this help information.
+    -v, --version            Display version information.
+    -n, --non-interactive    Run in non-interactive mode (selects all valid files).
+    -o, --output <file>      Output file path (default: "./codegrab-output.<format>").
+    -t, --temp               Use system temporary directory for output file.
+    -g, --glob <pattern>     Include/exclude files using glob patterns. Can be used multiple times.
+                             Prefix with '!' to exclude (e.g., -g="*.go" -g="\!*_test.go").
+                             Supports brace expansion (e.g., -g="*.{ts,tsx}").
+    -f, --format <format>    Output format. Available: markdown, text, xml (default: "markdown").
+    -S, --skip-redaction     Skip automatic secret redaction via gitleaks (Default: false).
                              WARNING: This may expose sensitive information!
-    --deps                   Automatically include direct dependencies (Go, JS/TS)
-    --max-depth depth        Maximum depth for dependency resolution (-1 for unlimited, default: 1)
-    --theme                  Set the UI theme (available: catppuccin-latte,
-                             catppuccin-frappe, catppuccin-macchiato,
-                             catppuccin-mocha, dracula, nord)
+    --deps                   Automatically include direct dependencies for selected files (Go, JS/TS).
+    --max-depth <depth>      Maximum depth for dependency resolution (-1 for unlimited, default: 1).
+                             Only effective when --deps is used.
+    --max-file-size <size>   Maximum file size to include (e.g., "50kb", "2MB"). No limit by default.
+                             Files exceeding this size will be skipped if the limit is set.
+    --theme <name>           Set the UI theme. Available: catppuccin-latte, catppuccin-frappe,
+                             catppuccin-macchiato, catppuccin-mocha, dracula, nord.
+                             (default: "catppuccin-mocha").
 
   Examples:
-    # Grab files in current directory interactively
+    # Run interactively in the current directory
     grab
 
     # Grab all files in current directory (non-interactive)
     grab -n
 
-    # Grab specific directory interactively including dependencies
+    # Run interactively in a specific directory, resolving dependencies
     grab --deps /path/to/project
 
     # Specify custom output file
     grab -o output.md /path/to/project
 
-    # Generate XML output
-    grab -f xml -o output.xml /path/to/project
+    # Generate XML output in a temporary file
+    grab --temp -f xml
 
-    # Filter files using glob pattern
-    grab -g="*.go" /path/to/project
+    # Filter files using glob pattern, skipping files > 50kb
+    grab -g="*.go" --max-file-size 50kb 
 
     # Multiple glob patterns
     grab -g="*.{ts,tsx}" -g="\!*.spec.{ts,tsx}"`

--- a/internal/utils/system.go
+++ b/internal/utils/system.go
@@ -1,12 +1,16 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"unicode"
 )
 
 // CopyFileObject attempts to place a "file object" onto the clipboard.
@@ -24,37 +28,129 @@ func CopyFileObject(filePath string) error {
 }
 
 // IsTextFile returns true if the file at filePath appears to be a text file.
+// It checks the content type and also looks for null bytes.
 func IsTextFile(filePath string) (bool, error) {
 	const sampleSize = 512
 
 	file, err := os.Open(filePath)
 	if err != nil {
 		if os.IsPermission(err) {
-			return false, fmt.Errorf("permission denied: %w", err)
+			fmt.Fprintf(os.Stderr, "Warning: Permission denied checking file type for %s\n", filePath)
+			return false, nil
 		}
-		return false, fmt.Errorf("failed to open file: %w", err)
+		return false, fmt.Errorf("failed to open file %s: %w", filePath, err)
 	}
 	defer file.Close()
 
 	buf := make([]byte, sampleSize)
 	n, err := file.Read(buf)
-	if err != nil {
-		return false, fmt.Errorf("failed to read file content: %w", err)
+	if err != nil && err.Error() != "EOF" {
+		return false, fmt.Errorf("failed to read file content for %s: %w", filePath, err)
+	}
+	if n == 0 {
+		return true, nil
 	}
 
-	contentType := http.DetectContentType(buf[:n])
-	// Allow common text types, including JSON
-	if !strings.HasPrefix(contentType, "text/") && contentType != "application/json" {
-		return false, nil
-	}
-	return true, nil
-}
+	buffer := buf[:n]
 
-func IsHiddenPath(path string) bool {
-	for _, part := range strings.Split(path, string(os.PathSeparator)) {
-		if strings.HasPrefix(part, ".") {
-			return true
+	contentType := http.DetectContentType(buffer)
+	isLikelyTextType := strings.HasPrefix(contentType, "text/") ||
+		contentType == "application/json" ||
+		contentType == "application/xml" ||
+		contentType == "application/javascript" ||
+		contentType == "application/octet-stream"
+
+	hasNullByte := false
+	for _, b := range buffer {
+		if b == 0 {
+			hasNullByte = true
+			break
 		}
 	}
+
+	if hasNullByte {
+		return false, nil
+	}
+
+	if isLikelyTextType {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// IsHiddenPath checks if any component of the path starts with a dot.
+func IsHiddenPath(path string) bool {
+	cleanedPath := filepath.Clean(path)
+	if strings.HasPrefix(filepath.Base(cleanedPath), ".") {
+		return true
+	}
+	current := cleanedPath
+	for {
+		parent := filepath.Dir(current)
+		if parent == "." || parent == "/" || parent == current {
+			break
+		}
+		if strings.HasPrefix(filepath.Base(parent), ".") {
+			return true
+		}
+		current = parent
+	}
 	return false
+}
+
+// ParseSizeString converts a human-readable size string (e.g., "100kb", "2MB") into bytes (int64).
+func ParseSizeString(sizeStr string) (int64, error) {
+	sizeStr = strings.TrimSpace(strings.ToLower(sizeStr))
+	if sizeStr == "" {
+		return 0, errors.New("size string cannot be empty")
+	}
+
+	var multiplier int64 = 1
+	var numPart string
+
+	// Separate numeric part from unit part
+	lastDigitIndex := -1
+	for i, r := range sizeStr {
+		if unicode.IsDigit(r) || r == '.' {
+			lastDigitIndex = i
+		} else {
+			break
+		}
+	}
+
+	if lastDigitIndex == -1 {
+		return 0, fmt.Errorf("invalid size format: no numeric part found in %q", sizeStr)
+	}
+
+	numPart = sizeStr[:lastDigitIndex+1]
+	unitPart := strings.TrimSpace(sizeStr[lastDigitIndex+1:])
+
+	switch unitPart {
+	case "", "b":
+		multiplier = 1
+	case "kb", "k":
+		multiplier = 1024
+	case "mb", "m":
+		multiplier = 1024 * 1024
+	case "gb", "g":
+		multiplier = 1024 * 1024 * 1024
+	case "tb", "t":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("invalid size unit: %q in %q", unitPart, sizeStr)
+	}
+
+	valueFloat, err := strconv.ParseFloat(numPart, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid numeric value %q: %w", numPart, err)
+	}
+
+	if valueFloat < 0 {
+		return 0, fmt.Errorf("size cannot be negative: %f", valueFloat)
+	}
+
+	bytesValue := int64(valueFloat * float64(multiplier))
+
+	return bytesValue, nil
 }

--- a/internal/utils/system_test.go
+++ b/internal/utils/system_test.go
@@ -1,0 +1,80 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestParseSizeString(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected int64
+		wantErr  bool
+	}{
+		// Basic units
+		{"1024", 1024, false},
+		{"1024b", 1024, false},
+		{"1k", 1024, false},
+		{"1kb", 1024, false},
+		{"1m", 1024 * 1024, false},
+		{"1mb", 1024 * 1024, false},
+		{"1g", 1024 * 1024 * 1024, false},
+		{"1gb", 1024 * 1024 * 1024, false},
+		{"1t", 1024 * 1024 * 1024 * 1024, false},
+		{"1tb", 1024 * 1024 * 1024 * 1024, false},
+
+		// Case insensitive
+		{"2KB", 2 * 1024, false},
+		{"3MB", 3 * 1024 * 1024, false},
+		{"4GB", 4 * 1024 * 1024 * 1024, false},
+		{"5TB", 5 * 1024 * 1024 * 1024 * 1024, false},
+
+		// Float values
+		{"1.5kb", int64(1.5 * 1024), false},
+		{"0.5MB", int64(0.5 * 1024 * 1024), false},
+		{"100.2b", 100, false},
+
+		// Zero
+		{"0", 0, false},
+		{"0kb", 0, false},
+
+		// Whitespace
+		{" 512kb ", 512 * 1024, false},
+		{"1 mb", 1024 * 1024, false},
+
+		// Max Int
+		{fmt.Sprintf("%d", math.MaxInt64), math.MaxInt64, false},
+
+		// Errors
+		{"", 0, true},          // Empty string
+		{"kb", 0, true},        // No number
+		{"10xx", 0, true},      // Invalid unit
+		{"-1kb", 0, true},      // Negative number
+		{"1.2.3kb", 0, true},   // Invalid number format
+		{"invalid", 0, true},   // Completely invalid
+		{"1eb", 0, true},       // Unsupported large unit
+		{"1 kb test", 0, true}, // Extra text after unit
+		{"1.5.mb", 0, true},    // Multiple decimals
+		{"1,024kb", 0, true},   // Comma in number
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := ParseSizeString(tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("ParseSizeString(%q) expected an error, but got nil", tc.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ParseSizeString(%q) unexpected error: %v", tc.input, err)
+				}
+				if result != tc.expected {
+					t.Errorf("ParseSizeString(%q) = %d, want %d", tc.input, result, tc.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

This pull request introduces a new command-line flag `--max-file-size` that allows users to specify a maximum size for files included during the code grabbing process. Files exceeding this limit will be skipped.

## Motivation

Users may want to exclude large files from the final output for several reasons:
*   They might be binary files, large assets, or log files not relevant for LLM context.
*   Very large source files can consume excessive tokens in LLM prompts.
*   Skipping large files can speed up the directory walking and generation process.

## Changes Implemented:

1.  **New CLI Flag:**
    *   Added a `--max-file-size` flag to `cmd/grab/main.go`.
    *   The flag accepts human-readable size formats (e.g., `50kb`, `2MB`, `1GB`).
    *   Defaults to no limit (`math.MaxInt64`) if the flag is not provided.
2.  **Size Parsing Utility:**
    *   Introduced `utils.ParseSizeString` in `internal/utils/system.go` to handle the conversion of human-readable size strings into `int64` byte values. Includes error handling for invalid formats.
3.  **Filesystem Walker Integration:**
    *   Modified `internal/filesystem/walker.go`'s `WalkDirectory` function to accept the `maxFileSize` limit.
    *   Files are checked against this limit *before* applying glob filters or checking if they are text files, optimizing the walk process.
    *   `FileItem` struct updated to include file `Size`.
4.  **Dependency Resolution Integration:**
    *   Updated the dependency resolution logic in both non-interactive mode (`cmd/grab/main.go`) and interactive mode (`internal/model/selection.go`) to check the size limit before adding a potential dependency file.
    *   Added a check within `getDirectDependencies` to avoid reading oversized files even before parsing attempts.

