### PR TITLE
feat(ui): Implement cursor highlighting in file tree

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -196,46 +196,57 @@ func (m *Model) refreshViewportContent() {
 
 		treePrefix := prefixBuilder.String() + treeBranch
 
-		dirIndicator := ""
+		rawDirIndicator := ""
 		if node.IsDir {
 			if m.collapsed[node.Path] {
-				dirIndicator = ui.StyleDirectoryName(" ")
+				rawDirIndicator = " "
 			} else {
-				dirIndicator = ui.StyleDirectoryName(" ")
+				rawDirIndicator = " "
 			}
 		}
 
-		var checkbox string
+		isPartialDir := !m.selected[node.Path] && dirsWithSelectedChildren[node.Path] && node.IsDir
+		rawCheckbox := "[ ]"
 		if node.IsDir {
 			if m.selected[node.Path] {
-				checkbox = ui.StyleCheckBox(true)
-			} else if dirsWithSelectedChildren[node.Path] {
-				checkbox = ui.StylePartialCheckBox()
-			} else {
-				checkbox = ui.StyleCheckBox(false)
+				rawCheckbox = "[x]"
+			} else if isPartialDir {
+				rawCheckbox = "[~]"
 			}
 		} else {
-			checkbox = ui.StyleCheckBox(node.Selected)
-		}
-
-		name := node.Name
-		depIndicator := ""
-		if node.IsDependency {
-			depIndicator = ui.GetStyleHelp().Render(" [dep]")
-		}
-		if node.IsDir {
-			name = ui.StyleDirectoryName(name + "/")
-			if count := dirSelectedCounts[node.Path]; count > 0 {
-				styledCount := ui.GetStyleHelp().Render(fmt.Sprintf("[%d]", count))
-				name = fmt.Sprintf("%s %s", name, styledCount)
+			if node.Selected {
+				rawCheckbox = "[x]"
 			}
 		}
 
-		isDeselected := !node.IsDir && m.deselected[node.Path]
+		rawName := node.Name
+		if node.IsDir {
+			rawName += "/"
+		}
 
-		lineContent := fmt.Sprintf("%s %s%s%s%s", checkbox, treePrefix, dirIndicator, name, depIndicator)
+		rawSuffix := ""
+		if node.IsDir {
+			if count := dirSelectedCounts[node.Path]; count > 0 {
+				rawSuffix = fmt.Sprintf(" [%d]", count)
+			}
+		} else if node.IsDependency {
+			rawSuffix = " [dep]"
+		}
 
-		rendered := ui.StyleFileLine(lineContent, node.IsDir, m.selected[node.Path], isDeselected, i == m.cursor)
+		isCursorLine := i == m.cursor
+
+		rendered := ui.StyleFileLine(
+			rawCheckbox,
+			treePrefix,
+			rawDirIndicator,
+			rawName,
+			rawSuffix,
+			node.IsDir,
+			m.selected[node.Path],
+			isCursorLine,
+			isPartialDir,
+			m.viewport.Width,
+		)
 		lines = append(lines, rendered)
 	}
 

--- a/internal/ui/themes/catppuccin_frappe.go
+++ b/internal/ui/themes/catppuccin_frappe.go
@@ -37,6 +37,8 @@ func NewCatppuccinFrappeTheme() Theme {
 			Text:      lipgloss.Color("#c6d0f5"), // text
 			Muted:     lipgloss.Color("#949cbb"), // overlay2
 			Highlight: lipgloss.Color("#f4b8e4"), // pink
+
+			HighlightBackground: lipgloss.Color("#414559"), // surface0
 		},
 	}
 }

--- a/internal/ui/themes/catppuccin_latte.go
+++ b/internal/ui/themes/catppuccin_latte.go
@@ -37,6 +37,8 @@ func NewCatppuccinLatteTheme() Theme {
 			Text:      lipgloss.Color("#4c4f69"), // text
 			Muted:     lipgloss.Color("#6c6f85"), // overlay2
 			Highlight: lipgloss.Color("#ea76cb"), // pink
+
+			HighlightBackground: lipgloss.Color("#ccd0da"), // surface0
 		},
 	}
 }

--- a/internal/ui/themes/catppuccin_macchiato.go
+++ b/internal/ui/themes/catppuccin_macchiato.go
@@ -37,6 +37,8 @@ func NewCatppuccinMacchiatoTheme() Theme {
 			Text:      lipgloss.Color("#cad3f5"), // text
 			Muted:     lipgloss.Color("#939ab7"), // overlay2
 			Highlight: lipgloss.Color("#f5bde6"), // pink
+
+			HighlightBackground: lipgloss.Color("#363a4f"), // surface0
 		},
 	}
 }

--- a/internal/ui/themes/catppuccin_mocha.go
+++ b/internal/ui/themes/catppuccin_mocha.go
@@ -37,6 +37,8 @@ func NewCatppuccinMochaTheme() Theme {
 			Text:      lipgloss.Color("#cdd6f4"), // text
 			Muted:     lipgloss.Color("#9399b2"), // overlay2
 			Highlight: lipgloss.Color("#f5c2e7"), // pink
+
+			HighlightBackground: lipgloss.Color("#313244"), // surface0
 		},
 	}
 }

--- a/internal/ui/themes/dracula.go
+++ b/internal/ui/themes/dracula.go
@@ -33,6 +33,8 @@ func NewDraculaTheme() Theme {
 			Text:      lipgloss.Color("#f8f8f2"), // foreground
 			Muted:     lipgloss.Color("#6272a4"), // comment
 			Highlight: lipgloss.Color("#ff79c6"), // pink
+
+			HighlightBackground: lipgloss.Color("#44475a"), // current line
 		},
 	}
 }

--- a/internal/ui/themes/nord.go
+++ b/internal/ui/themes/nord.go
@@ -37,6 +37,8 @@ func NewNordTheme() Theme {
 			Text:      lipgloss.Color("#eceff4"), // nord6
 			Muted:     lipgloss.Color("#7b88a1"), // between nord3 and nord4
 			Highlight: lipgloss.Color("#88c0d0"), // nord8
+
+			HighlightBackground: lipgloss.Color("#3b4252"), // nord1
 		},
 	}
 }

--- a/internal/ui/themes/theme.go
+++ b/internal/ui/themes/theme.go
@@ -34,6 +34,8 @@ type ColorPalette struct {
 	Text      lipgloss.Color
 	Muted     lipgloss.Color
 	Highlight lipgloss.Color
+
+	HighlightBackground lipgloss.Color
 }
 
 // Theme interface provides colors for the UI


### PR DESCRIPTION
## **Description**

This PR enhances the user experience of the file tree view, specifically aiming to make selections easier, particularly within large or complex directory structures. It achieves this by introducing full-width highlighting for the line currently under the cursor.

Previously, only the text content of the cursor line was styled differently. This could sometimes make it difficult to quickly identify the active line and track the cursor's position, especially when navigating extensive file lists.

By applying a background highlight across the entire width of the viewport for the cursor line, this change significantly improves the visibility of the current selection, making navigation more intuitive and reducing cognitive load.

## **Changes**

1.  **Refactored `internal/ui/styles.go`:**
    *   Modified the `StyleFileLine` function to accept raw line components (checkbox, prefix, indicator, name, suffix), state flags (`isDir`, `isSelected`, `isCursor`, `isPartialDir`), and the `viewportWidth`.
    *   Implemented conditional logic within `StyleFileLine`:
        *   For the cursor line (`isCursor == true`):
            *   Applies a new `HighlightBackground` color across the full width of the line.
            *   Calculates necessary padding to fill the viewport width.
            *   Individually styles each component (checkbox, prefix, name, etc.) ensuring they inherit the background color and appropriate foreground colors based on their state and the theme.
        *   For non-cursor lines:
            *   Styles components individually based on their state (selected, partial, directory, etc.) without the full-width background.
    *   Removed the now-redundant helper functions `StyleCheckBox`, `StylePartialCheckBox`, and `StyleDirectoryName` as their logic is integrated into `StyleFileLine`.

2.  **Updated `internal/model/view.go`:**
    *   Modified `refreshViewportContent` to prepare raw string representations of the line components (e.g., `rawCheckbox`, `rawName`, `rawSuffix`).
    *   Updated the call to `ui.StyleFileLine` to pass the new required arguments, including the raw components, state flags, and `m.viewport.Width`.

3.  **Enhanced `internal/ui/themes/`:**
    *   Added a new `HighlightBackground` field to the `ColorPalette` struct in `theme.go`.
    *   Defined appropriate `HighlightBackground` color values for all existing themes (Catppuccin variants, Dracula, Nord) to ensure consistency across different visual styles.

## Screenshots

| Before       | After        |
|--------------|-------------|
| ![codegrab-no-highlight](https://github.com/user-attachments/assets/adfca663-89de-406d-aa5d-abdd057d030b) | ![codegrab-highlight](https://github.com/user-attachments/assets/1dfdb4aa-1c1e-4127-8258-b360b6bfbb6a) |

