### PR TITLE
Add Rosé Pine theme and variations

### DIFF
--- a/internal/ui/themes/rose_pine.go
+++ b/internal/ui/themes/rose_pine.go
@@ -1,0 +1,54 @@
+package themes
+
+import "github.com/charmbracelet/lipgloss"
+
+// RosePineTheme implements the Theme interface with Rosé Pine colors
+type RosePineTheme struct {
+	colors ColorPalette
+}
+
+// NewRosePineTheme creates a new instance of the Rosé Pine theme
+func NewRosePineTheme() Theme {
+	return &RosePineTheme{
+		colors: ColorPalette{
+			// Base colors from Rosé Pine
+			Primary:   lipgloss.Color("#c4a7e7"), // iris
+			Secondary: lipgloss.Color("#ebbcba"), // rose
+			Tertiary:  lipgloss.Color("#f6c177"), // gold
+
+			// UI element colors
+			Background: lipgloss.Color("#191724"), // base
+			Foreground: lipgloss.Color("#1f1d2e"), // surface
+			Border:     lipgloss.Color("#524f67"), // highlight high
+
+			// Semantic colors
+			Success: lipgloss.Color("#31748f"), // pine
+			Error:   lipgloss.Color("#eb6f92"), // love
+			Warning: lipgloss.Color("#f6c177"), // gold
+			Info:    lipgloss.Color("#9ccfd8"), // foam
+
+			// File/directory colors
+			Directory:  lipgloss.Color("#9ccfd8"), // foam
+			File:       lipgloss.Color("#1f1d2e"), // surface
+			Selected:   lipgloss.Color("#ebbcba"), // rose
+			Deselected: lipgloss.Color("#908caa"), // muted
+
+			// Text colors
+			Text:      lipgloss.Color("#e0def4"), // text
+			Muted:     lipgloss.Color("#908caa"), // muted
+			Highlight: lipgloss.Color("#ebbcba"), // rose
+
+			HighlightBackground: lipgloss.Color("#403d52"), // highlight med
+		},
+	}
+}
+
+// Colors returns the color palette
+func (t *RosePineTheme) Colors() ColorPalette {
+	return t.colors
+}
+
+// Name returns the theme name
+func (t *RosePineTheme) Name() string {
+	return "rose-pine"
+}

--- a/internal/ui/themes/rose_pine_dawn.go
+++ b/internal/ui/themes/rose_pine_dawn.go
@@ -1,0 +1,54 @@
+package themes
+
+import "github.com/charmbracelet/lipgloss"
+
+// RosePineDawnTheme implements the Theme interface with Rosé Pine Dawn colors
+type RosePineDawnTheme struct {
+	colors ColorPalette
+}
+
+// NewRosePineTheme creates a new instance of the Rosé Pine Dawn theme
+func NewRosePineDawnTheme() Theme {
+	return &RosePineDawnTheme{
+		colors: ColorPalette{
+			// Base colors from Rosé Pine Dawn
+			Primary:   lipgloss.Color("#907aa9"), // iris
+			Secondary: lipgloss.Color("#d7827e"), // rose
+			Tertiary:  lipgloss.Color("#ea9d34"), // gold
+
+			// UI element colors
+			Background: lipgloss.Color("#faf4ed"), // base
+			Foreground: lipgloss.Color("#fffaf3"), // surface
+			Border:     lipgloss.Color("#cecacd"), // highlight high
+
+			// Semantic colors
+			Success: lipgloss.Color("#286983"), // pine
+			Error:   lipgloss.Color("#b4637a"), // love
+			Warning: lipgloss.Color("#ea9d34"), // gold
+			Info:    lipgloss.Color("#56949f"), // foam
+
+			// File/directory colors
+			Directory:  lipgloss.Color("#56949f"), // foam
+			File:       lipgloss.Color("#fffaf3"), // surface
+			Selected:   lipgloss.Color("#d7827e"), // rose
+			Deselected: lipgloss.Color("#9893a5"), // muted
+
+			// Text colors
+			Text:      lipgloss.Color("#575279"), // text
+			Muted:     lipgloss.Color("#9893a5"), // muted
+			Highlight: lipgloss.Color("#d7827e"), // rose
+
+			HighlightBackground: lipgloss.Color("#dfdad9"), // highlight med
+		},
+	}
+}
+
+// Colors returns the color palette
+func (t *RosePineDawnTheme) Colors() ColorPalette {
+	return t.colors
+}
+
+// Name returns the theme name
+func (t *RosePineDawnTheme) Name() string {
+	return "rose-pine-dawn"
+}

--- a/internal/ui/themes/rose_pine_moon.go
+++ b/internal/ui/themes/rose_pine_moon.go
@@ -1,0 +1,54 @@
+package themes
+
+import "github.com/charmbracelet/lipgloss"
+
+// RosePineMoonTheme implements the Theme interface with Rosé Pine Moon colors
+type RosePineMoonTheme struct {
+	colors ColorPalette
+}
+
+// NewRosePineTheme creates a new instance of the Rosé Pine Moon theme
+func NewRosePineMoonTheme() Theme {
+	return &RosePineMoonTheme{
+		colors: ColorPalette{
+			// Base colors from Rosé Pine Moon
+			Primary:   lipgloss.Color("#c4a7e7"), // iris
+			Secondary: lipgloss.Color("#ea9a97"), // rose
+			Tertiary:  lipgloss.Color("#f6c177"), // gold
+
+			// UI element colors
+			Background: lipgloss.Color("#232136"), // base
+			Foreground: lipgloss.Color("#2a273f"), // surface
+			Border:     lipgloss.Color("#56526e"), // highlight high
+
+			// Semantic colors
+			Success: lipgloss.Color("#3e8fb0"), // pine
+			Error:   lipgloss.Color("#eb6f92"), // love
+			Warning: lipgloss.Color("#f6c177"), // gold
+			Info:    lipgloss.Color("#9ccfd8"), // foam
+
+			// File/directory colors
+			Directory:  lipgloss.Color("#9ccfd8"), // foam
+			File:       lipgloss.Color("#2a273f"), // surface
+			Selected:   lipgloss.Color("#ea9a97"), // rose
+			Deselected: lipgloss.Color("#6e6a86"), // muted
+
+			// Text colors
+			Text:      lipgloss.Color("#e0def4"), // text
+			Muted:     lipgloss.Color("#6e6a86"), // muted
+			Highlight: lipgloss.Color("#ea9a97"), // rose
+
+			HighlightBackground: lipgloss.Color("#44415a"), // highlight med
+		},
+	}
+}
+
+// Colors returns the color palette
+func (t *RosePineMoonTheme) Colors() ColorPalette {
+	return t.colors
+}
+
+// Name returns the theme name
+func (t *RosePineMoonTheme) Name() string {
+	return "rose-pine-moon"
+}

--- a/internal/ui/themes/theme.go
+++ b/internal/ui/themes/theme.go
@@ -67,6 +67,9 @@ func Initialize() {
 	RegisterTheme("catppuccin-mocha", NewCatppuccinMochaTheme)
 	RegisterTheme("dracula", NewDraculaTheme)
 	RegisterTheme("nord", NewNordTheme)
+	RegisterTheme("rose-pine", NewRosePineTheme)
+	RegisterTheme("rose-pine-dawn", NewRosePineDawnTheme)
+	RegisterTheme("rose-pine-moon", NewRosePineMoonTheme)
 
 	// Set default theme
 	SetTheme("catppuccin-mocha")


### PR DESCRIPTION
Adds [Rosé Pine](https://rosepinetheme.com/) themes to Codegrab!

## Rosé Pine
![Screenshot 2025-04-25 at 3 44 06 PM](https://github.com/user-attachments/assets/a193917a-cc83-4eab-b4a1-8a81afb7080e)

## Rosé Pine Dawn
(Intended for lighter backgrounds which my terminal does not have configured)
![Screenshot 2025-04-25 at 3 53 45 PM](https://github.com/user-attachments/assets/2f28f207-3afc-4e5d-a02c-fb609730bfe9)

## Rosé Pine Moon
![Screenshot 2025-04-25 at 3 52 10 PM](https://github.com/user-attachments/assets/e1e76814-71bc-4029-94f9-f8f3116b3182)
