### PR TITLE
Add token counts in view

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ grab [options] [directory]
 | `--max-depth <depth>`    | Maximum depth for dependency resolution (`-1` for unlimited, default: `1`). Only effective with `--deps`.                                                                                            |
 | `--max-file-size <size>` | Maximum file size to include (e.g., `"100kb"`, `"2MB"`). No limit by default. Files exceeding the specified size will be skipped.                                                                    |
 | `--theme <name>`         | Set the UI theme. Available: catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, catppuccin-mocha, rose-pine, rose-pine-dawn, rose-pine-moon, dracula, nord. (default: `"catppuccin-mocha"`). |
+| `--show-tokens`          | Show the number of tokens for each file in file tree. |
 
 ### 📖 Examples
 

--- a/cmd/grab/main.go
+++ b/cmd/grab/main.go
@@ -47,6 +47,7 @@ func main() {
 	var resolveDeps bool
 	var maxDepth int
 	var maxFileSizeStr string
+	var showTokenCount bool
 
 	flag.BoolVar(&showHelp, "help", false, "Display help information")
 	flag.BoolVar(&showHelp, "h", false, "Display help information (shorthand)")
@@ -84,6 +85,8 @@ func main() {
 
 	maxFileSizeUsage := "Maximum file size to include (e.g., 50kb, 2MB). No limit by default."
 	flag.StringVar(&maxFileSizeStr, "max-file-size", "", maxFileSizeUsage)
+
+	flag.BoolVar(&showTokenCount, "show-tokens", false, "Show the number of tokens for each file")
 
 	flag.Parse()
 
@@ -154,15 +157,16 @@ func main() {
 		runNonInteractive(root, filterMgr, outputPath, useTempFile, formatName, skipRedaction, resolveDeps, maxDepth, maxFileSize)
 	} else {
 		config := model.Config{
-			RootPath:      root,
-			FilterMgr:     filterMgr,
-			OutputPath:    outputPath,
-			UseTempFile:   useTempFile,
-			Format:        formatName,
-			SkipRedaction: skipRedaction,
-			ResolveDeps:   resolveDeps,
-			MaxDepth:      maxDepth,
-			MaxFileSize:   maxFileSize,
+			RootPath:       root,
+			FilterMgr:      filterMgr,
+			OutputPath:     outputPath,
+			UseTempFile:    useTempFile,
+			Format:         formatName,
+			SkipRedaction:  skipRedaction,
+			ResolveDeps:    resolveDeps,
+			MaxDepth:       maxDepth,
+			MaxFileSize:    maxFileSize,
+			ShowTokenCount: showTokenCount,
 		}
 
 		m := model.NewModel(config)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -56,18 +56,20 @@ type Model struct {
 	isGrabbing        bool
 	redactSecrets     bool
 	resolveDeps       bool
+	showTokenCount    bool
 }
 
 type Config struct {
-	FilterMgr     *filesystem.FilterManager
-	RootPath      string
-	OutputPath    string
-	Format        string
-	MaxDepth      int
-	MaxFileSize   int64
-	UseTempFile   bool
-	SkipRedaction bool
-	ResolveDeps   bool
+	FilterMgr      *filesystem.FilterManager
+	RootPath       string
+	OutputPath     string
+	Format         string
+	MaxDepth       int
+	MaxFileSize    int64
+	UseTempFile    bool
+	SkipRedaction  bool
+	ResolveDeps    bool
+	ShowTokenCount bool
 }
 
 func NewModel(config Config) Model {
@@ -105,6 +107,7 @@ func NewModel(config Config) Model {
 			Width:  80,
 			Height: 10,
 		},
-		cursor: 0,
+		cursor:         0,
+		showTokenCount: config.ShowTokenCount,
 	}
 }

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -2,9 +2,9 @@ package model
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
-	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/epilande/codegrab/internal/ui"
@@ -235,11 +235,13 @@ func (m *Model) refreshViewportContent() {
 			if node.IsDependency {
 				rawSuffix += " [dep]"
 			}
-			if ok, err := utils.IsTextFile(node.Path); ok && err == nil {
-				if contentBytes, err := os.ReadFile(node.Path); err == nil {
-					content := string(contentBytes)
-					tokensEstimate := utils.EstimateTokens(content)
-					rawSuffix += fmt.Sprintf(" [%d tokens]", tokensEstimate)
+			if m.showTokenCount {
+				if ok, err := utils.IsTextFile(node.Path); ok && err == nil {
+					if contentBytes, err := os.ReadFile(node.Path); err == nil {
+						content := string(contentBytes)
+						tokensEstimate := utils.EstimateTokens(content)
+						rawSuffix += fmt.Sprintf(" [%d tokens]", tokensEstimate)
+					}
 				}
 			}
 		}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -229,7 +229,7 @@ func (m *Model) refreshViewportContent() {
 		rawSuffix := ""
 		if node.IsDir {
 			if count := dirSelectedCounts[node.Path]; count > 0 {
-				rawSuffix = fmt.Sprintf(" [%d 📄]", count)
+				rawSuffix = fmt.Sprintf(" [%d]", count)
 			}
 		} else {
 			if node.IsDependency {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -54,6 +54,7 @@ const UsageText = `Usage:
     --theme <name>           Set the UI theme. Available: catppuccin-latte, catppuccin-frappe,
                              catppuccin-macchiato, catppuccin-mocha, rose-pine, rose-pine-dawn,
 	                           rose-pine-moon, dracula, nord. (default: "catppuccin-mocha").
+    --show-tokens            Show the number of tokens for each file in file tree.
 
   Examples:
     # Run interactively in the current directory


### PR DESCRIPTION
Add a flag `--show-tokens` that if passed in, will displays token counts alongside each file

* command:
![image](https://github.com/user-attachments/assets/cb33afd9-deda-4573-84dd-de84cd5afb75)

* tui:
<img width="991" alt="image" src="https://github.com/user-attachments/assets/3b079136-6cbb-4efb-8fdc-a313571a0c8d" />

* potential issues
  * this estimate doesn't take the formatting overhead of each file into account