### PR TITLE
feat(ui): Add nerd font icon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ grab [options] [directory]
 | `--max-depth <depth>`    | Maximum depth for dependency resolution (`-1` for unlimited, default: `1`). Only effective with `--deps`.                                                                                            |
 | `--max-file-size <size>` | Maximum file size to include (e.g., `"100kb"`, `"2MB"`). No limit by default. Files exceeding the specified size will be skipped.                                                                    |
 | `--theme <name>`         | Set the UI theme. Available: catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, catppuccin-mocha, rose-pine, rose-pine-dawn, rose-pine-moon, dracula, nord. (default: `"catppuccin-mocha"`). |
-| `--show-tokens`          | Show the number of tokens for each file in file tree. |
+| `--show-tokens`          | Show the number of tokens for each file in file tree.                                                                                                                                                |
+| `--icons`                | Display Nerd Font icons.                                                                                                                                                                             |
 
 ### 📖 Examples
 

--- a/cmd/grab/main.go
+++ b/cmd/grab/main.go
@@ -47,6 +47,7 @@ func main() {
 	var resolveDeps bool
 	var maxDepth int
 	var maxFileSizeStr string
+	var showIcons bool
 	var showTokenCount bool
 
 	flag.BoolVar(&showHelp, "help", false, "Display help information")
@@ -85,6 +86,8 @@ func main() {
 
 	maxFileSizeUsage := "Maximum file size to include (e.g., 50kb, 2MB). No limit by default."
 	flag.StringVar(&maxFileSizeStr, "max-file-size", "", maxFileSizeUsage)
+
+	flag.BoolVar(&showIcons, "icons", false, "Display Nerd Font icons")
 
 	flag.BoolVar(&showTokenCount, "show-tokens", false, "Show the number of tokens for each file")
 
@@ -164,9 +167,10 @@ func main() {
 			Format:         formatName,
 			SkipRedaction:  skipRedaction,
 			ResolveDeps:    resolveDeps,
+			ShowIcons:      showIcons,
+			ShowTokenCount: showTokenCount,
 			MaxDepth:       maxDepth,
 			MaxFileSize:    maxFileSize,
-			ShowTokenCount: showTokenCount,
 		}
 
 		m := model.NewModel(config)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
+	github.com/epilande/go-devicons v0.0.0-20250502062109-89b44a507be9
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/zricethezav/gitleaks/v8 v8.24.2

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/epilande/go-devicons v0.0.0-20250430064519-26ca6d272b4c h1:ZKFmMr4EQ+6wni8gHq56tEmjMdIDySQ+zFgwXi+yCgc=
+github.com/epilande/go-devicons v0.0.0-20250430064519-26ca6d272b4c/go.mod h1:myBNrCUxmCh3ktYaRUMfL8epmWMBu6/yj0JFnQHYFSU=
+github.com/epilande/go-devicons v0.0.0-20250502062109-89b44a507be9 h1:wu8xPucxiGFKrSN24fE9VVzjthnfVqYFx33bNoRL8DU=
+github.com/epilande/go-devicons v0.0.0-20250502062109-89b44a507be9/go.mod h1:myBNrCUxmCh3ktYaRUMfL8epmWMBu6/yj0JFnQHYFSU=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=

--- a/internal/model/display.go
+++ b/internal/model/display.go
@@ -7,13 +7,10 @@ import (
 	"strings"
 
 	"github.com/epilande/codegrab/internal/filesystem"
+	"github.com/epilande/go-devicons"
 )
 
 // buildDisplayNodes constructs a hierarchical view of files and directories for display.
-// It creates FileNode objects for each item, properly indented based on directory depth,
-// respects collapsed/expanded states of directories, marks selected/deselected items,
-// identifies dependencies, and sorts files and directories.
-// The resulting displayNodes slice is used for rendering the file tree in the UI.
 func (m *Model) buildDisplayNodes() {
 	m.displayNodes = nil
 	nodesToAdd := make(map[string]filesystem.FileItem)
@@ -31,6 +28,15 @@ func (m *Model) buildDisplayNodes() {
 		}
 		processed[item.Path] = true
 
+		icon := ""
+		iconColor := ""
+		if m.showIcons {
+			fullPath := filepath.Join(m.rootPath, item.Path)
+			style := devicons.IconForPath(fullPath)
+			icon = style.Icon
+			iconColor = style.Color
+		}
+
 		node := FileNode{
 			Path:         item.Path,
 			Name:         filepath.Base(item.Path),
@@ -39,6 +45,8 @@ func (m *Model) buildDisplayNodes() {
 			Selected:     m.selected[item.Path],
 			IsDeselected: m.deselected[item.Path],
 			IsDependency: m.isDependency[item.Path],
+			Icon:         icon,
+			IconColor:    iconColor,
 		}
 		m.displayNodes = append(m.displayNodes, node)
 
@@ -55,6 +63,7 @@ func (m *Model) buildDisplayNodes() {
 					}
 				}
 			}
+
 			for _, childItem := range directChildren {
 				children = append(children, childItem)
 			}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -18,6 +18,8 @@ import (
 type FileNode struct {
 	Path         string
 	Name         string
+	Icon         string
+	IconColor    string
 	Level        int
 	IsDir        bool
 	IsLast       bool
@@ -52,6 +54,7 @@ type Model struct {
 	showHelp          bool
 	useGitIgnore      bool
 	showHidden        bool
+	showIcons         bool
 	isSearching       bool
 	isGrabbing        bool
 	redactSecrets     bool
@@ -69,6 +72,7 @@ type Config struct {
 	UseTempFile    bool
 	SkipRedaction  bool
 	ResolveDeps    bool
+	ShowIcons      bool
 	ShowTokenCount bool
 }
 
@@ -98,6 +102,7 @@ func NewModel(config Config) Model {
 		generator:         gen,
 		redactSecrets:     !config.SkipRedaction,
 		resolveDeps:       config.ResolveDeps,
+		showIcons:         config.ShowIcons,
 		maxDepth:          config.MaxDepth,
 		maxFileSize:       config.MaxFileSize,
 		projectModuleName: moduleName,

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -53,8 +53,9 @@ const UsageText = `Usage:
                              Files exceeding this size will be skipped if the limit is set.
     --theme <name>           Set the UI theme. Available: catppuccin-latte, catppuccin-frappe,
                              catppuccin-macchiato, catppuccin-mocha, rose-pine, rose-pine-dawn,
-	                           rose-pine-moon, dracula, nord. (default: "catppuccin-mocha").
+                             rose-pine-moon, dracula, nord. (default: "catppuccin-mocha").
     --show-tokens            Show the number of tokens for each file in file tree.
+    --icons                  Display Nerd Font icons. 
 
   Examples:
     # Run interactively in the current directory


### PR DESCRIPTION
## Description

This PR introduces an optional `--icons` flag to display file type icons in the TUI using Nerd Font glyphs. These icons are colored by the [`go-devicons`](https://github.com/epilande/go-devicons) library based on file extensions and names, enhancing the visual identification of files and directories in the tree view.

Resolves #10.

### Motivation

Displaying icons next to file and directory names provides a quick visual cue about the item type, improving the user experience when navigating project structures, especially in projects with diverse file types.

### Changes

*   **New CLI Flag:** Added an `--icons` boolean flag to `cmd/grab/main.go` to enable the feature.
*   **Dependency:** Integrated the [`github.com/epilande/go-devicons`](https://github.com/epilande/go-devicons) library to determine the appropriate icon and color based on file name and extension.
*   **TUI Update:**
    *   The `FileNode` struct now includes `Icon` and `IconColor` fields.
    *   The `buildDisplayNodes` function populates these fields when the `--icons` flag is active.
    *   The `refreshViewportContent` and `StyleFileLine` functions in `internal/model/view.go` and `internal/ui/styles.go` respectively have been updated to render the icon with its specific color (or theme default for directories) next to the file/directory name.
*   **Prerequisite:** Users need to have a [Nerd Font](https://www.nerdfonts.com/) installed and configured in their terminal to see the icons correctly.

## Screenshots 

<img width="933" alt="image" src="https://github.com/user-attachments/assets/53e62abd-ea9d-4538-a453-344c0cf9f140" />
