### PR TITLE
feat(output): Add tree-only mode for structure-only output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ to your clipboard, ready for LLM processing.
 - ⏳ **Temp File**: Generate the output file in your system's temporary directory
 - 📋 **Clipboard Integration**: Copy content or output file directly to your clipboard
 - 🌲 **Directory Tree View**: Display a tree-style view of your project structure
+- 🌳 **Tree-Only Mode**: Output just the file structure without contents using `-T` flag
 - 🧮 **Token Estimation**: Get estimated token count for LLM context windows
 - 🛡️ **Secret Detection & Redaction**: Uses [gitleaks](https://github.com/gitleaks/gitleaks) to identify potential secrets and prevent sharing sensitive information
 - 🔗 **Dependency Resolution**: Automatically include dependencies for Go, JS/TS, Python when using the `--deps` flag
@@ -108,6 +109,7 @@ grab [options] [directory]
 | `--theme <name>`         | Set the UI theme. Available: catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, catppuccin-mocha, rose-pine, rose-pine-dawn, rose-pine-moon, dracula, nord. (default: `"catppuccin-mocha"`). |
 | `--show-tokens`          | Show the number of tokens for each file in file tree.                                                                                                                                                |
 | `--icons`                | Display Nerd Font icons.                                                                                                                                                                             |
+| `-T, --tree-only`        | Output only file structure without contents. Useful for sharing project layout with LLMs.                                                                                                           |
 
 ### 📖 Examples
 
@@ -177,6 +179,12 @@ grab [options] [directory]
     grab git@github.com:user/repo.git
     ```
 
+12. Output only the project structure (no file contents):
+
+    ```bash
+    grab -T -n
+    ```
+
 ## ⌨️ Keyboard Controls
 
 ### Navigation
@@ -211,6 +219,7 @@ grab [options] [directory]
 | Toggle Dependency Resolution | <kbd>D</kbd>                       | Enable/disable automatic dependency resolution for Go & JS/TS (Default: Off) |
 | Cycle output formats         | <kbd>F</kbd>                       | Cycle through available output formats (markdown, text, xml)                 |
 | Toggle Secret Redaction      | <kbd>S</kbd>                       | Enable/disable automatic secret redaction (Default: On)                      |
+| Toggle Tree-Only Mode        | <kbd>T</kbd>                       | Output only file structure without contents (Default: Off)                   |
 
 ### View Options
 

--- a/cmd/grab/main.go
+++ b/cmd/grab/main.go
@@ -50,6 +50,7 @@ func main() {
 	var maxFileSizeStr string
 	var showIcons bool
 	var showTokenCount bool
+	var treeOnly bool
 
 	flag.BoolVar(&showHelp, "help", false, "Display help information")
 	flag.BoolVar(&showHelp, "h", false, "Display help information (shorthand)")
@@ -91,6 +92,9 @@ func main() {
 	flag.BoolVar(&showIcons, "icons", false, "Display Nerd Font icons")
 
 	flag.BoolVar(&showTokenCount, "show-tokens", false, "Show the number of tokens for each file")
+
+	flag.BoolVar(&treeOnly, "tree-only", false, "Output only file structure without contents")
+	flag.BoolVar(&treeOnly, "T", false, "Output only file structure (shorthand)")
 
 	flag.Parse()
 
@@ -187,7 +191,7 @@ func main() {
 	}
 
 	if nonInteractive {
-		runNonInteractive(root, filterMgr, outputPath, useTempFile, formatName, skipRedaction, resolveDeps, maxDepth, maxFileSize)
+		runNonInteractive(root, filterMgr, outputPath, useTempFile, formatName, skipRedaction, resolveDeps, maxDepth, maxFileSize, treeOnly)
 	} else {
 		config := model.Config{
 			RootPath:       root,
@@ -201,6 +205,7 @@ func main() {
 			ShowTokenCount: showTokenCount,
 			MaxDepth:       maxDepth,
 			MaxFileSize:    maxFileSize,
+			TreeOnly:       treeOnly,
 		}
 
 		m := model.NewModel(config)
@@ -213,7 +218,7 @@ func main() {
 }
 
 // runNonInteractive processes files and generates output without user interaction
-func runNonInteractive(rootPath string, filterMgr *filesystem.FilterManager, outputPath string, useTempFile bool, formatName string, skipRedaction bool, resolveDeps bool, maxDepth int, maxFileSize int64) {
+func runNonInteractive(rootPath string, filterMgr *filesystem.FilterManager, outputPath string, useTempFile bool, formatName string, skipRedaction bool, resolveDeps bool, maxDepth int, maxFileSize int64, treeOnly bool) {
 	gitIgnoreMgr, err := filesystem.NewGitIgnoreManager(rootPath)
 	if err != nil {
 		log.Fatalf("Error reading .gitignore: %v\n", err)
@@ -301,6 +306,7 @@ func runNonInteractive(rootPath string, filterMgr *filesystem.FilterManager, out
 	format := formats.GetFormat(formatName)
 	gen.SetFormat(format)
 	gen.SetRedactionMode(!skipRedaction)
+	gen.SetTreeOnlyMode(treeOnly)
 
 	gen.SelectedFiles = selectedFiles
 

--- a/internal/generator/format.go
+++ b/internal/generator/format.go
@@ -14,6 +14,7 @@ type FileData struct {
 type TemplateData struct {
 	Structure string
 	Files     []FileData
+	FilePaths []string
 }
 
 // Format defines the interface for different output formats

--- a/internal/generator/formats/formats_test.go
+++ b/internal/generator/formats/formats_test.go
@@ -153,6 +153,7 @@ func createTestTemplateData() generator.TemplateData {
 				Language: "go",
 			},
 		},
+		FilePaths: []string{"main.go"},
 	}
 }
 
@@ -160,6 +161,7 @@ func createTreeOnlyTemplateData() generator.TemplateData {
 	return generator.TemplateData{
 		Structure: "test-project/\n├── src/\n│   └── main.go\n└── README.md\n",
 		Files:     []generator.FileData{},
+		FilePaths: []string{"src/main.go", "README.md"},
 	}
 }
 
@@ -224,8 +226,19 @@ func TestXMLFormatTreeOnly(t *testing.T) {
 	if !strings.Contains(content, "<project>") {
 		t.Errorf("Expected content to contain '<project>'")
 	}
+	// Directory structure should be built from FilePaths
+	if !strings.Contains(content, "<directory name=\"src\">") {
+		t.Errorf("Expected content to contain '<directory name=\"src\">' from FilePaths")
+	}
+	if !strings.Contains(content, "<file name=\"main.go\">") {
+		t.Errorf("Expected content to contain '<file name=\"main.go\">' in filesystem section")
+	}
+	if !strings.Contains(content, "<file name=\"README.md\">") {
+		t.Errorf("Expected content to contain '<file name=\"README.md\">' in filesystem section")
+	}
+	// Files section should be empty (no file contents)
 	if strings.Contains(content, "<file path=") {
-		t.Errorf("Expected content to NOT contain file elements in tree-only mode")
+		t.Errorf("Expected content to NOT contain file content elements in tree-only mode")
 	}
 	if tokens <= 0 {
 		t.Errorf("Expected tokens to be positive, got %d", tokens)

--- a/internal/generator/formats/formats_test.go
+++ b/internal/generator/formats/formats_test.go
@@ -156,6 +156,82 @@ func createTestTemplateData() generator.TemplateData {
 	}
 }
 
+func createTreeOnlyTemplateData() generator.TemplateData {
+	return generator.TemplateData{
+		Structure: "test-project/\n├── src/\n│   └── main.go\n└── README.md\n",
+		Files:     []generator.FileData{},
+	}
+}
+
+func TestMarkdownFormatTreeOnly(t *testing.T) {
+	format := &MarkdownFormat{}
+	data := createTreeOnlyTemplateData()
+
+	content, tokens, err := format.Render(data)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if !strings.Contains(content, "# Project Structure") {
+		t.Errorf("Expected content to contain '# Project Structure'")
+	}
+	if !strings.Contains(content, "test-project/") {
+		t.Errorf("Expected content to contain 'test-project/'")
+	}
+	if strings.Contains(content, "# Project Files") {
+		t.Errorf("Expected content to NOT contain '# Project Files' in tree-only mode")
+	}
+	if tokens <= 0 {
+		t.Errorf("Expected tokens to be positive, got %d", tokens)
+	}
+}
+
+func TestTxtFormatTreeOnly(t *testing.T) {
+	format := &TxtFormat{}
+	data := createTreeOnlyTemplateData()
+
+	content, tokens, err := format.Render(data)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if !strings.Contains(content, "PROJECT STRUCTURE") {
+		t.Errorf("Expected content to contain 'PROJECT STRUCTURE'")
+	}
+	if !strings.Contains(content, "test-project/") {
+		t.Errorf("Expected content to contain 'test-project/'")
+	}
+	if strings.Contains(content, "PROJECT FILES") {
+		t.Errorf("Expected content to NOT contain 'PROJECT FILES' in tree-only mode")
+	}
+	if tokens <= 0 {
+		t.Errorf("Expected tokens to be positive, got %d", tokens)
+	}
+}
+
+func TestXMLFormatTreeOnly(t *testing.T) {
+	format := &XMLFormat{}
+	data := createTreeOnlyTemplateData()
+
+	content, tokens, err := format.Render(data)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if !strings.Contains(content, "<?xml") {
+		t.Errorf("Expected content to contain '<?xml'")
+	}
+	if !strings.Contains(content, "<project>") {
+		t.Errorf("Expected content to contain '<project>'")
+	}
+	if strings.Contains(content, "<file path=") {
+		t.Errorf("Expected content to NOT contain file elements in tree-only mode")
+	}
+	if tokens <= 0 {
+		t.Errorf("Expected tokens to be positive, got %d", tokens)
+	}
+}
+
 func TestAddFileToTree(t *testing.T) {
 	root := &directoryEntry{
 		name:    ".",

--- a/internal/generator/formats/markdown.go
+++ b/internal/generator/formats/markdown.go
@@ -44,7 +44,7 @@ const markdownTemplate = `# Project Structure
 
 ` + "```" + `
 {{.Structure}}` + "```" + `
-
+{{if .Files}}
 # Project Files
 {{range .Files}}
 ## File: ` + "`" + `{{.Path}}` + "`" + `
@@ -52,5 +52,4 @@ const markdownTemplate = `# Project Structure
 ` + "```" + `{{.Language}}
 {{.Content}}
 ` + "```" + `
-{{end}}
-`
+{{end}}{{end}}`

--- a/internal/generator/formats/text.go
+++ b/internal/generator/formats/text.go
@@ -57,7 +57,7 @@ PROJECT STRUCTURE
 {{separator}}
 
 {{.Structure}}
-
+{{if .Files}}
 {{separator}}
 PROJECT FILES
 {{separator}}
@@ -67,5 +67,4 @@ FILE: {{.Path}}
 {{separator .Path}}
 
 {{.Content}}
-{{end}}
-`
+{{end}}{{end}}`

--- a/internal/generator/formats/xml.go
+++ b/internal/generator/formats/xml.go
@@ -61,9 +61,8 @@ func (f *XMLFormat) Render(data generator.TemplateData) (string, int, error) {
 		files:   []string{},
 	}
 
-	// Get all file paths from the files data
-	for _, file := range data.Files {
-		addFileToTree(root, file.Path)
+	for _, path := range data.FilePaths {
+		addFileToTree(root, path)
 	}
 
 	// Convert our internal tree to the XML structure

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -26,6 +26,7 @@ type Generator struct {
 	UseGitIgnore    bool
 	ShowHidden      bool
 	RedactSecrets   bool
+	TreeOnly        bool
 	lastSecretCount int
 }
 
@@ -73,6 +74,11 @@ func (g *Generator) GetFormatName() string {
 // SetRedactionMode enables or disables secret redaction.
 func (g *Generator) SetRedactionMode(redact bool) {
 	g.RedactSecrets = redact
+}
+
+// SetTreeOnlyMode enables or disables tree-only output (structure without file contents).
+func (g *Generator) SetTreeOnlyMode(treeOnly bool) {
+	g.TreeOnly = treeOnly
 }
 
 // Generate creates an output file in the specified format
@@ -211,7 +217,9 @@ func (g *Generator) PrepareTemplateData() (TemplateData, error) {
 	}
 
 	var filesData []FileData
-	collectFiles(rootNode, &filesData, g.RootPath, &g.SecretScanner)
+	if !g.TreeOnly {
+		collectFiles(rootNode, &filesData, g.RootPath, &g.SecretScanner)
+	}
 
 	secretCount := 0
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -202,6 +202,11 @@ func (g *Generator) PrepareTemplateData() (TemplateData, error) {
 
 	g.SelectedFiles = expandedSelection
 
+	filePaths := make([]string, 0, len(expandedSelection))
+	for path := range expandedSelection {
+		filePaths = append(filePaths, path)
+	}
+
 	rootNode := g.buildTree()
 	var structureBuilder strings.Builder
 	baseRootName := filepath.Base(g.RootPath)
@@ -239,5 +244,6 @@ func (g *Generator) PrepareTemplateData() (TemplateData, error) {
 	return TemplateData{
 		Structure: structureBuilder.String(),
 		Files:     filesData,
+		FilePaths: filePaths,
 	}, nil
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -151,6 +151,11 @@ func TestPrepareTemplateData(t *testing.T) {
 			t.Errorf("Expected language for %q to be %q, got %q", tf.path, "go", file.Language)
 		}
 	}
+
+	// Verify FilePaths is also populated
+	if len(data.FilePaths) != 3 {
+		t.Errorf("Expected FilePaths to have 3 entries, got %d", len(data.FilePaths))
+	}
 }
 
 func TestGenerateString(t *testing.T) {
@@ -281,6 +286,10 @@ func TestPrepareTemplateDataTreeOnly(t *testing.T) {
 	}
 	if len(data.Files) != 0 {
 		t.Errorf("Expected Files to be empty in tree-only mode, got %d files", len(data.Files))
+	}
+	// FilePaths should still be populated for XML format support
+	if len(data.FilePaths) != 3 {
+		t.Errorf("Expected FilePaths to have 3 entries in tree-only mode, got %d", len(data.FilePaths))
 	}
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -214,6 +214,76 @@ func TestGenerateStringWithNoFormat(t *testing.T) {
 	}
 }
 
+func TestSetTreeOnlyMode(t *testing.T) {
+	gen := NewGenerator(".", nil, nil, "", false)
+
+	if gen.TreeOnly {
+		t.Errorf("Expected TreeOnly to be false by default")
+	}
+
+	gen.SetTreeOnlyMode(true)
+	if !gen.TreeOnly {
+		t.Errorf("Expected TreeOnly to be true after SetTreeOnlyMode(true)")
+	}
+
+	gen.SetTreeOnlyMode(false)
+	if gen.TreeOnly {
+		t.Errorf("Expected TreeOnly to be false after SetTreeOnlyMode(false)")
+	}
+}
+
+func TestPrepareTemplateDataTreeOnly(t *testing.T) {
+	cache.ResetGlobalCache()
+
+	tempDir, err := os.MkdirTemp("", "generator-test-treeonly")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	testFiles := []struct {
+		path    string
+		content string
+	}{
+		{"file1.txt", "Content of file1"},
+		{"file2.go", "package main\n\nfunc main() {}"},
+		{"subdir/file3.txt", "Content of file3"},
+	}
+
+	for _, tf := range testFiles {
+		path := filepath.Join(tempDir, filepath.FromSlash(tf.path))
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", dir, err)
+		}
+		if err := os.WriteFile(path, []byte(tf.content), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", path, err)
+		}
+	}
+
+	gitIgnoreMgr, _ := filesystem.NewGitIgnoreManager(tempDir)
+	filterMgr := filesystem.NewFilterManager()
+	gen := NewGenerator(tempDir, gitIgnoreMgr, filterMgr, "", false)
+	gen.SelectedFiles = map[string]bool{
+		"file1.txt":        true,
+		"file2.go":         true,
+		"subdir/file3.txt": true,
+	}
+	gen.SetTreeOnlyMode(true)
+
+	data, err := gen.PrepareTemplateData()
+	if err != nil {
+		t.Fatalf("PrepareTemplateData failed: %v", err)
+	}
+
+	if data.Structure == "" {
+		t.Errorf("Expected Structure to be non-empty in tree-only mode")
+	}
+	if len(data.Files) != 0 {
+		t.Errorf("Expected Files to be empty in tree-only mode, got %d files", len(data.Files))
+	}
+}
+
 type mockFormat struct {
 	err       error
 	name      string

--- a/internal/model/init_update.go
+++ b/internal/model/init_update.go
@@ -471,6 +471,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.warningMsg = ""
 			m.refreshViewportContent()
+		case "T":
+			m.treeOnly = !m.treeOnly
+			m.generator.SetTreeOnlyMode(m.treeOnly)
+			if m.treeOnly {
+				m.successMsg = "Tree-only mode enabled (structure only)"
+			} else {
+				m.successMsg = "Tree-only mode disabled (full output)"
+			}
+			m.refreshViewportContent()
 		case "P":
 			// Toggle preview pane
 			m.showPreview = !m.showPreview

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -70,6 +70,7 @@ type Model struct {
 	currentPreviewPath    string
 	currentPreviewContent string
 	currentPreviewIsDir   bool
+	treeOnly              bool
 	lastKeyTime           int64  // Last key press time
 	lastKey               string // Last key pressed
 	tokenCache            *TokenCache
@@ -87,6 +88,7 @@ type Config struct {
 	ResolveDeps    bool
 	ShowIcons      bool
 	ShowTokenCount bool
+	TreeOnly       bool
 }
 
 // updatePreview reads the content of the file at the cursor and updates the preview viewport
@@ -193,6 +195,7 @@ func NewModel(config Config) Model {
 	format := formats.GetFormat(config.Format)
 	gen.SetFormat(format)
 	gen.SetRedactionMode(!config.SkipRedaction)
+	gen.SetTreeOnlyMode(config.TreeOnly)
 
 	moduleName := dependencies.ReadGoModFile(config.RootPath)
 
@@ -225,6 +228,7 @@ func NewModel(config Config) Model {
 		cursor:         0,
 		showTokenCount: config.ShowTokenCount,
 		showPreview:    false,
+		treeOnly:       config.TreeOnly,
 		tokenCache:     NewTokenCache(),
 	}
 }

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -353,6 +353,11 @@ func (m Model) renderFooter() string {
 		rightParts = append(rightParts, ui.GetStyleInfo().Render(" | 🔗 Deps"))
 	}
 
+	// Tree-only status
+	if m.treeOnly {
+		rightParts = append(rightParts, ui.GetStyleInfo().Render(" | 🌳 Tree"))
+	}
+
 	leftContent := lipgloss.JoinHorizontal(lipgloss.Top, leftParts...)
 	rightContent := lipgloss.JoinHorizontal(lipgloss.Top, rightParts...)
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -21,6 +21,7 @@ Selection & Output:
   D                        Toggle automatic dependency resolution (Go, TS/JS)
   F                        Cycle through output formats (md, txt, xml)
   S                        Toggle secret redaction (Default: On)
+  T                        Toggle tree-only mode (structure without contents)
 
 View Options:
   i                        Toggle .gitignore filter
@@ -66,6 +67,7 @@ const UsageText = `Usage:
                              rose-pine-moon, dracula, nord. (default: "catppuccin-mocha").
     --show-tokens            Show the number of tokens for each file in file tree.
     --icons                  Display Nerd Font icons.
+    -T, --tree-only          Output only file structure without contents.
 
   Examples:
     # Run interactively in the current directory


### PR DESCRIPTION
## Overview
Adds a new tree-only mode (`-T` / `--tree-only` flag) that outputs only the file structure without file contents. This is useful for sharing project layouts with LLMs when you want to provide context about code organization without consuming tokens on file contents.

## Motivation
When working with LLMs, there are scenarios where you want to share your project structure to help the model understand the codebase organization, without needing the actual file contents. This saves significant tokens and provides a quick way to communicate project layout.

Resolves #22 

## Changes

### CLI & Configuration
- Added `-T` / `--tree-only` flags to `cmd/grab/main.go`
- Extended `model.Config` with `TreeOnly` field
- Updated `runNonInteractive()` to support tree-only mode

### Generator
- Added `TreeOnly` field to `Generator` struct
- Added `SetTreeOnlyMode()` method
- Added `FilePaths` field to `TemplateData` for XML format support
- Modified `PrepareTemplateData()` to skip file content collection in tree-only mode

### Output Formats
- **Markdown**: Added `{{if .Files}}` conditional to hide "Project Files" section
- **Text**: Added `{{if .Files}}` conditional to hide "PROJECT FILES" section
- **XML**: Updated to use `FilePaths` for building directory structure (works in both modes)

### TUI
- Added `T` key binding to toggle tree-only mode
- Added 🌳 indicator in footer when tree-only mode is active
- Updated help text with new keybinding

### Documentation
- Updated README.md with new flag documentation
- Added example usage: `grab -T -n`
- Added keyboard control documentation for `T` key

## Breaking Changes
None

## Testing
- Added `TestSetTreeOnlyMode` - verifies mode toggling
- Added `TestPrepareTemplateDataTreeOnly` - verifies generator produces structure without file contents
- Added `TestMarkdownFormatTreeOnly` - verifies markdown output excludes file section
- Added `TestTxtFormatTreeOnly` - verifies text output excludes file section
- Added `TestXMLFormatTreeOnly` - verifies XML output has filesystem structure but no file contents
- All existing tests pass
- Manual testing: `./grab -T -n` produces structure-only output



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tree-Only mode (-T / --tree-only flag) to output file structure without file contents
  * Added keyboard toggle (T key) for Tree-Only mode in interactive mode
  * Added UI footer indicator showing when Tree-Only mode is active

* **Documentation**
  * Updated CLI options documentation with the new -T/--tree-only flag
  * Added usage examples demonstrating Tree-Only mode

* **Tests**
  * Added test coverage for Tree-Only mode rendering across multiple output formats

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->